### PR TITLE
Improved readability

### DIFF
--- a/JavaScript/6-http-safeStart.js
+++ b/JavaScript/6-http-safeStart.js
@@ -13,7 +13,6 @@ const once = (fn) => (...args) => {
 
 const prepareCache = (callback) => {
   callback = once(callback);
-  let buffer = null;
 
   const rs = fs.createReadStream('index.html');
   const gs = zlib.createGzip();
@@ -24,8 +23,8 @@ const prepareCache = (callback) => {
     buffers.push(buffer);
   });
 
-  gs.once('end', () => {
-    buffer = Buffer.concat(buffers);
+  gs.on('end', () => {
+    const buffer = Buffer.concat(buffers);
     callback(null, buffer);
   });
 


### PR DESCRIPTION
Now for the identifier "buffer" the const keyword is used instead of let and is declared no earlier than we need.
The "end" event now listens for events via "on" since the callback is wrapped via the once function.